### PR TITLE
Fix docs (install commands and macaroon in example)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,11 @@ services:
 - Add ``config.yaml`` file to the ``lndnotify`` directory and adjust the configuration
 
 ### 💻 Run without Docker
+
 ```bash
-go install github.com/Primexz/lndnotify@latest
+git clone https://github.com/Primexz/lndnotify.git
+cd lndnotify
+go install ./cmd/lnd-notify
 ```
 
 ## Configuration
@@ -109,7 +112,7 @@ To see the full list of supported providers, check out the [official documentati
 ## Usage
 
 ```bash
-lndnotify -config config.yaml
+lnd-notify -config config.yaml
 ```
 
 ## Development
@@ -119,7 +122,7 @@ lndnotify -config config.yaml
 ```bash
 git clone https://github.com/Primexz/lndnotify.git
 cd lndnotify
-go build -o lndnotify cmd/lndnotify/main.go
+go build -o lndnotify cmd/lnd-notify/main.go
 ```
 
 ## Contributing

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,7 +3,7 @@ lnd:
   host: "localhost"
   port: 10009
   tls_cert_path: "~/.lnd/tls.cert"
-  macaroon_path: "~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon"
+  macaroon_path: "~/.lnd/data/chain/bitcoin/mainnet/readonly.macaroon"
 
 # Notification settings
 notifications:


### PR DESCRIPTION
Hey,
I wasn't able to install it with the commands in README.md. I am not so deep in the package system of golang .

Analysis with Claude:
go install github.com/Primexz/lndnotify@latest fails due to replace directive in go.mod

One thing I don't like at the moment is that the binary generated by go install is named `lnd-notify`. After `go build`, it is called `lndnotify` (without dash).


