### PR TITLE
feature: add connect and disconnect message

### DIFF
--- a/cmd/lnd-notify/main.go
+++ b/cmd/lnd-notify/main.go
@@ -70,6 +70,9 @@ func main() {
 		Templates: cfg.Notifications.Templates,
 	})
 
+	notifier.Send("🟢 lndnotify connected")
+	defer notifier.Send("🔴 lndnotify disconnected")
+
 	// Create event processor
 	processor := events.NewProcessor(&events.ProcessorConfig{
 		EnabledEvents: cfg.Events,


### PR DESCRIPTION
That makes sense to me, to see if the notifier has established a clean connection. Otherwise, you have to wait until the first event.