### PR TITLE
fix: move time of status event notification

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -42,15 +42,15 @@ func Run(configPath string) {
 		Templates: cfg.Notifications.Templates,
 	})
 
-	if cfg.Events.StatusEvents {
-		notifier.Send("🟢 lndnotify connected")
-		defer notifier.Send("🔴 lndnotify disconnected")
-	}
-
 	// Subscribe to events
 	eventChan, err := lndClient.SubscribeEvents()
 	if err != nil {
 		log.Fatalf("Failed to subscribe to events: %v", err)
+	}
+
+	if cfg.Events.StatusEvents {
+		notifier.Send("🟢 lndnotify connected")
+		defer notifier.Send("🔴 lndnotify disconnected")
 	}
 
 	// Handle shutdown gracefully


### PR DESCRIPTION
prevents sending of multiple notifications if lndClient.SubscribeEvents fails (e.g. because lnd ist starting and server not active) and lndnotify is retried externally.